### PR TITLE
fix: OFPA name translation Friendshipper compat

### DIFF
--- a/Source/FriendshipperCore/Private/FriendshipperTranslateOFPAFilenamesCommandlet.cpp
+++ b/Source/FriendshipperCore/Private/FriendshipperTranslateOFPAFilenamesCommandlet.cpp
@@ -13,6 +13,35 @@ int32 UTranslateOFPAFilenamesCommandlet::Main(const FString& Params)
 
 	UCommandlet::ParseCommandLine(*Params, Tokens, Switches, SwitchParams);
 
+	if (FString* ListFilePath = SwitchParams.Find(TEXT("ListFile")))
+	{
+		Tokens.Reset();
+
+		// Trim surrounding single quotes if present. Friendshipper passes this string in single quotes to safely
+		// handle spaces in the path.
+		if (ListFilePath->StartsWith("'"))
+		{
+			ListFilePath->RightChopInline(1, EAllowShrinking::No);
+		}
+
+		if (ListFilePath->EndsWith("'"))
+		{
+			ListFilePath->LeftChopInline(1, EAllowShrinking::No);
+		}
+
+		FString FileContents;
+		if (FFileHelper::LoadFileToString(FileContents, **ListFilePath) == false)
+		{
+			UE_LOG(LogFriendshipperTranslateOFPAFilenamesCommandlet, Error,
+				TEXT("Unable to find provided ListFile '%s'. Unable to translate filenames."),
+				**ListFilePath);
+			return 1;
+		}
+
+		bool bInCullEmpty = true;
+		FileContents.ParseIntoArray(Tokens, TEXT("\n"), bInCullEmpty); // friendshipper always writes newlines only
+	}
+
 	TArray<FAssetFriendlyName> FriendlyNames = OfpaUtils::TranslatePackagePaths(Tokens); // We expect Tokens to be FilePaths
 
 	for (const FAssetFriendlyName& FriendlyName : FriendlyNames)

--- a/Source/FriendshipperCore/Private/FriendshipperTranslateOFPAFilenamesCommandlet.h
+++ b/Source/FriendshipperCore/Private/FriendshipperTranslateOFPAFilenamesCommandlet.h
@@ -9,10 +9,14 @@
 //
 // Usage:
 //
-//   UnrealEditor-Cmd.exe <PathToUProject> -run=TranslateOFPAFilenames <Space separated filenames.>
 //
+//   UnrealEditor-Cmd.exe <PathToUProject> -run=TranslateOFPAFilenames [-ListFile=<Path/to/file>] [Space separated filenames]
 // Arguments:
-//		Paths to assets to translate. Specify a space-separated list of paths. For example:
+//     Listfile (optional): Instead of looking for names of paths as arguments to the commandlet, reads a file for a
+//       newline-separated list of paths. This option is provided to get around the commandline length limits. If this
+//       option is specified, only filenames given in the listfile will be translated.
+//
+//	   Paths to assets to translate. Specify a space-separated list of paths. For example:
 //       -run=TranslateOFPAFilenames D:/repos/fellowship/Plugins/GameFeatures/ShooterMaps/Content/__ExternalActors__/Maps/L_Convolution_Blockout/0/CR/ZZ6IFPOFLPOW1WBSFYOPW6.uasset
 //       -run=TranslateOFPAFilenames D:/repos/fellowship/Content/__ExternalObjects__/Levels/DevTest/Traversal/L_TraversalGym/0/Z0/ZZGHJ5DWZEAJAM6BNQYL8O.uasset
 //       -run=TranslateOFPAFilenames Content/__ExternalObjects__/Levels/DevTest/Traversal/L_TraversalGym/0/Z0/ZZGHJ5DWZEAJAM6BNQYL8O.uasset Content/__ExternalActors__/Levels/DevTest/Combat/L_CombatGym/C/BO/ZZGR76KX8SMOWJNZAZ63KX.uasset


### PR DESCRIPTION
* Add a ListFile param to support passing filename translation requests via file instead of commandline. Often OFPA workloads generate more paths than the Windows commandline length limits can handle.